### PR TITLE
fix: [issue 5] no searchbar cursor

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -51,6 +51,7 @@ entry {
     border: none;
     box-shadow: none;
     padding: 2px;
+    caret-color: #FFFFFF;
 }
 
 entry:focus {

--- a/data/application.css
+++ b/data/application.css
@@ -44,3 +44,18 @@
 /*  font-size: 16px;
     padding: 2px;    */
 }
+
+entry {
+    background: transparent;
+    color: #FFFFFF;
+    border: none;
+    box-shadow: none;
+    padding: 2px;
+}
+
+entry:focus {
+    background: transparent;
+    color: #FFFFFF;
+    border: none;
+    box-shadow: none;
+}

--- a/meson.build
+++ b/meson.build
@@ -65,7 +65,7 @@ executable(
         meson.get_compiler('c').find_library('m', required: false)
     ],
     c_args: [
-        '-DGMENU_I_KNOW_THIS_IS_UNSTABLE',
+        '-DGMENU_I_KNOW_THIS_IS_UNSTABLE', '-w'
     ],
     vala_args: LightpadValaArgs,
     include_directories: config_inc_dir,

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -207,7 +207,8 @@ public class LightPadWindow : Widgets.CompositedWindow {
             // based on this widget.
             int x, y;
             int w, h;
-            this.searchbar.get_pointer(out x, out y);
+            Gdk.Window window = this.searchbar.get_window();
+            window.get_device_position(Gdk.Display.get_default().get_default_seat().get_pointer(), out x, out y, null);
             this.searchbar.get_size_request(out w, out h);
             if (( (x <= w) && (x >= 0) ) && ( (y <= h) && (y >= 0) )) {
                 return false;
@@ -408,7 +409,9 @@ public class LightPadWindow : Widgets.CompositedWindow {
                 }
                 return true;
             case "BackSpace":
-                this.searchbar.text = this.searchbar.text.slice (0, (int) this.searchbar.text.length - 1);
+                if (this.searchbar.text.length > 0) {   
+                    this.searchbar.text = this.searchbar.text.slice (0, (int) this.searchbar.text.length - 1);
+                }
                 return true;
             case "Left":
                 var current_item = this.grid.get_children ().index (this.get_focus ());

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -207,8 +207,7 @@ public class LightPadWindow : Widgets.CompositedWindow {
             // based on this widget.
             int x, y;
             int w, h;
-            Gdk.Window window = this.searchbar.get_window();
-            window.get_device_position(Gdk.Display.get_default().get_default_seat().get_pointer(), out x, out y, null);
+            this.searchbar.get_pointer(out x, out y);
             this.searchbar.get_size_request(out w, out h);
             if (( (x <= w) && (x >= 0) ) && ( (y <= h) && (y >= 0) )) {
                 return false;

--- a/src/DesktopEntries.vala
+++ b/src/DesktopEntries.vala
@@ -65,7 +65,8 @@ namespace LightPad.Backend {
                     case GMenu.TreeItemType.HEADER:
                     case GMenu.TreeItemType.SEPARATOR:
                     case GMenu.TreeItemType.ALIAS:
-                        // Ignoramos estos tipos ya que no son relevantes para nuestra aplicación
+                    case GMenu.TreeItemType.INVALID:
+                        // We ignore these types as they are not relevant to our application.
                         break;
                 }
                 item = iter.next ();

--- a/src/DesktopEntries.vala
+++ b/src/DesktopEntries.vala
@@ -62,6 +62,11 @@ namespace LightPad.Backend {
                     case GMenu.TreeItemType.ENTRY:
                         entries.add ((GMenu.TreeEntry) iter.get_entry ());
                         break;
+                    case GMenu.TreeItemType.HEADER:
+                    case GMenu.TreeItemType.SEPARATOR:
+                    case GMenu.TreeItemType.ALIAS:
+                        // Ignoramos estos tipos ya que no son relevantes para nuestra aplicación
+                        break;
                 }
                 item = iter.next ();
             }

--- a/src/Widgets/Searchbar.vala
+++ b/src/Widgets/Searchbar.vala
@@ -48,7 +48,6 @@ namespace LightPad.Frontend {
             set {
                 this.buffer.text = value;
                 if (this.buffer.text == "") {
-                    warning ("hint");
                     this.hint ();
                 } else {
                     this.reset_font ();

--- a/src/Widgets/Searchbar.vala
+++ b/src/Widgets/Searchbar.vala
@@ -29,7 +29,7 @@ namespace LightPad.Frontend {
         
         // Properties
         private Gtk.TextBuffer buffer;
-        public Gtk.Label label;
+        public Gtk.Entry entry;
         public Gtk.Image search_icon;
         private Gtk.Image clear_icon;
         /* protects against bug where get_text() will return ""
@@ -48,11 +48,11 @@ namespace LightPad.Frontend {
             set {
                 this.buffer.text = value;
                 if (this.buffer.text == "") {
+                    warning ("hint");
                     this.hint ();
                 } else {
                     this.reset_font ();
-                    this.label.label = this.buffer.text;
-                    this.label.select_region (-1, -1);
+                    this.entry.set_text (this.buffer.text);
                     this.clear_icon.visible = true;
                 }
             }
@@ -83,14 +83,14 @@ namespace LightPad.Frontend {
             wrapper.pack_start (search_icon_wrapper, false, true, 3);
             
             // Label properties
-            this.label = new Gtk.Label (this.buffer.text);
-            // Mode to compress the text and add "..."
-            this.label.set_ellipsize (Pango.EllipsizeMode.START);
-            this.label.set_alignment(0.0f, 0.5f);
-            this.label.selectable = true;
-            this.label.can_focus = false;
-            this.label.set_single_line_mode (true);
-            wrapper.pack_start (this.label, true, true, 0);
+            this.entry = new Gtk.Entry ();
+            this.entry.set_text (this.buffer.text);
+            this.entry.set_has_frame (false);
+            this.entry.set_alignment(0.0f);
+            this.entry.set_placeholder_text (this.hint_string);
+            this.entry.set_hexpand (true);
+            this.entry.set_halign (Gtk.Align.START);
+            wrapper.pack_start (this.entry, true, true, 0);
 
             // Clear icon
             var clear_icon_wrapper = new Gtk.EventBox ();
@@ -114,7 +114,7 @@ namespace LightPad.Frontend {
         
         public void hint () {
             this.buffer.text = "";
-            this.label.label = this.hint_string;
+            this.entry.set_text (this.hint_string);
             this.clear_icon.visible = false;
         }
 
@@ -124,8 +124,8 @@ namespace LightPad.Frontend {
         }
         
         private void reset_font () {
-            this.label.get_style_context ().remove_class ("search_greyout");
-            this.label.get_style_context ().add_class ("search_normal");
+            this.entry.get_style_context ().remove_class ("search_greyout");
+            this.entry.get_style_context ().add_class ("search_normal");
             this.is_hinted = false;
         }
 


### PR DESCRIPTION
- `Gtk.Label` is replaced by `Gtk.Entry` in Searchbar widget to include cursor blinking
- CSS styles are added for `Gtk.Entry` object
- The flag `-w` is added to meson build to avoid cpp warnings
- Avoid to slice searchbar text when there are no text on it