### PR TITLE
fix: [issue-9] shortcut to close lightpad doesn't work properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ sudo apt-get install com.github.libredeb.lightpad
    ```
    3. Create a build folder:
    ```
-      $ meson build --prefix=/usr
+      $ meson setup build --prefix=/usr
    ```
    4. Compile LightPad:
    ```
@@ -65,7 +65,9 @@ Once installed set shortcut key to access LightPad.
   * Name: LightPad
   * Command: com.github.libredeb.lightpad
 
-Now assign it a shortcut key, such as CTRL+SPACE.
+Now assign it a shortcut key, such as `CTRL`+`SPACE`.
+
+> **NOTE:** if you want to use another keyboard shortcut like the `SUPER` key to activate LightPad in Desktop Environments in which the `SUPER` key is used, maybe you want to try to disable the it first. For example in GNOME Shell you can run next command `gsettings set org.gnome.mutter overlay-key ''` (and if you want to restorte the original behavior, so run next command `gsettings reset org.gnome.mutter overlay-key`).
 
 **Note:** Some themes don't have the 'application-default-icon'. LightPad needs to have this icon, so please download it from the [elementary_os/icons](https://github.com/elementary/icons/blob/master/apps/128/application-default-icon.svg) pack and execute the following commands:
 ```
@@ -80,10 +82,10 @@ LighPad added a new feature, now you can use a custom background of your choice.
 
 > `$HOME/.lightpad/background.png`
 
-## Blacklist File (optional feature)
+## Blocklist File (optional feature)
 
-Another new added functionality, is the ability to hide applications using a blacklist file. In the file:
-> `$HOME/.lightpad/blacklist`
+Another new added functionality, is the ability to hide applications using a blocklist file. In the file:
+> `$HOME/.lightpad/blocklist`
 
 You must add line by line the full name of the binaries of the applications you want to hide in LightPad. For example:
 ```
@@ -105,6 +107,8 @@ These lines appear in the **.desktop** files located in `/usr/share/applications
 * Fixed [issue #26](https://github.com/libredeb/lightpad/issues/26), opens in wrong monitor
 * Fixed [issue #28](https://github.com/libredeb/lightpad/issues/28), can't run gnome apps
 * Fixed [issue #23](https://github.com/libredeb/lightpad/issues/23), can't exit clicking on an empty area
+* Fixed [issue #5](https://github.com/libredeb/lightpad/issues/5), there are no cursor blinking in the searchbar
+* Fixed [issue #9](https://github.com/libredeb/lightpad/issues/9), can't toggle lightpad via keyboard shortcut
 * Release in progress... 
 
 **Version 0.0.8**

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
     'com.github.libredeb.lightpad',
     'vala', 'c',
     version: '0.0.8',
-    meson_version: '>=0.45.0'
+    meson_version: '>=0.56.0'
 )
 
 PROJECT_NAME = 'lightpad'
@@ -11,8 +11,7 @@ prefix = get_option('prefix')
 libdir = join_paths(prefix, get_option('libdir'))
 datadir = join_paths(prefix, get_option('datadir'))
 
-VAPI_DIR = join_paths(meson.source_root(),
-                      'vapi')
+VAPI_DIR = join_paths(meson.project_source_root(), 'vapi')
 vala = meson.get_compiler('vala')
 
 # Global configuration data - matches vapi/config.vapi strings

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -389,8 +389,19 @@ public class LightPadWindow : Widgets.CompositedWindow {
 
     // Keyboard shortcuts
     public override bool key_press_event (Gdk.EventKey event) {
+        message ("Key pressed: %s", Gdk.keyval_name (event.keyval));
         switch (Gdk.keyval_name (event.keyval)) {
             case "Escape":
+                this.destroy ();
+                return true;
+            case "space":
+                if (event.state == Gdk.ModifierType.CONTROL_MASK) {
+                    this.destroy ();
+                    return true;
+                }
+                this.searchbar.text = this.searchbar.text + event.str;
+                break;
+            case "Super_L":
                 this.destroy ();
                 return true;
             case "ISO_Left_Tab":

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -389,7 +389,6 @@ public class LightPadWindow : Widgets.CompositedWindow {
 
     // Keyboard shortcuts
     public override bool key_press_event (Gdk.EventKey event) {
-        message ("Key pressed: %s", Gdk.keyval_name (event.keyval));
         switch (Gdk.keyval_name (event.keyval)) {
             case "Escape":
                 this.destroy ();

--- a/src/DesktopEntries.vala
+++ b/src/DesktopEntries.vala
@@ -96,12 +96,12 @@ namespace LightPad.Backend {
             var icon_theme = Gtk.IconTheme.get_default();
             list = new Gee.ArrayList<Gee.HashMap<string, string>> ();
             
-            var blacklist_file = GLib.File.new_for_path (user_home + Resources.BLACKLIST_FILE);
+            var blocklist_file = GLib.File.new_for_path (user_home + Resources.BLOCKLIST_FILE);
             var apps_hidden = new Gee.ArrayList<string> ();
             
-            if (blacklist_file.query_exists ()) {
+            if (blocklist_file.query_exists ()) {
                 try {
-                    var dis = new DataInputStream (blacklist_file.read ());
+                    var dis = new DataInputStream (blocklist_file.read ());
                     string line;
             
                     while ((line = dis.read_line (null)) != null) {

--- a/src/Resources.vala
+++ b/src/Resources.vala
@@ -24,6 +24,6 @@
  */
 namespace Resources {
      public const string LIGHTPAD_CONFIG_DIR = "/." + Config.PROJECT_NAME;
-     public const string BLACKLIST_FILE = LIGHTPAD_CONFIG_DIR + "/blacklist";
+     public const string BLOCKLIST_FILE = LIGHTPAD_CONFIG_DIR + "/blocklist";
      public const string CONFIG_FILE = LIGHTPAD_CONFIG_DIR + "/config";
 }


### PR DESCRIPTION
- Shortcurs `Ctrl + space` and `Super` are added to close LightPad (so, now you can configure the toggle behavior properly).
- Updated some deprecated **meson** instructions.