### PR TITLE
fix: [issue-16] xterm dependency is no longer needed

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,11 +1,11 @@
 pkgname=lightpad
-pkgver=0.0.7
-pkgrel=3
+pkgver=0.0.8
+pkgrel=1
 pkgdesc="Lightweight, simple and powerful application launcher"
 arch=('x86_64')
 url="https://github.com/libredeb/lightpad"
 license=('GPL3')
-depends=('libgee>=0.18.0' 'gnome-menus>=3.13.0' 'libwnck3>=3.20.0' 'glib2>=2.50.0' 'glibc>=2.28.0' 'gtk3>=3.22.0' 'cairo>=1.15.0' 'gdk-pixbuf2>=2.36.0' 'xterm')
+depends=('libgee>=0.18.0' 'gnome-menus>=3.13.0' 'libwnck3>=3.20.0' 'glib2>=2.76.0' 'glibc>=2.28.0' 'gtk3>=3.22.0' 'cairo>=1.15.0' 'gdk-pixbuf2>=2.36.0')
 makedepends=('meson' 'ninja' 'vala>=0.28.0')
 source=("https://github.com/libredeb/lightpad/archive/v$pkgver.tar.gz")
 sha256sums=("SKIP")

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ These lines appear in the **.desktop** files located in `/usr/share/applications
 * Fixed [issue #23](https://github.com/libredeb/lightpad/issues/23), can't exit clicking on an empty area
 * Fixed [issue #5](https://github.com/libredeb/lightpad/issues/5), there are no cursor blinking in the searchbar
 * Fixed [issue #9](https://github.com/libredeb/lightpad/issues/9), can't toggle lightpad via keyboard shortcut
+* Fixed [issue #16](https://github.com/libredeb/lightpad/issues/16), dependency xterm is no longer required
 * Release in progress... 
 
 **Version 0.0.8**

--- a/README.md
+++ b/README.md
@@ -24,15 +24,15 @@ sudo apt-get install com.github.libredeb.lightpad
    1. Install dependencies:
    * For Ubuntu:
       ```
-      sudo apt-get install meson ninja-build libgee-0.8-dev libgnome-menu-3-dev cdbs valac libvala-*-dev libglib2.0-dev libwnck-3-dev libgtk-3-dev xterm python3 python3-wheel python3-setuptools gnome-menus
+      sudo apt-get install meson ninja-build libgee-0.8-dev libgnome-menu-3-dev cdbs valac libvala-*-dev libglib2.0-dev libwnck-3-dev libgtk-3-dev python3 python3-wheel python3-setuptools gnome-menus
       ```
    * For Fedora:
       ```
-      sudo dnf install meson ninja-build libgee-devel gnome-menus-devel cdbs vala libvala-devel glib-devel libwnck-devel gtk3-devel xterm python3 python3-wheel python3-setuptools gnome-menus
+      sudo dnf install meson ninja-build libgee-devel gnome-menus-devel cdbs vala libvala-devel glib-devel libwnck-devel gtk3-devel python3 python3-wheel python3-setuptools gnome-menus
       ```
    * For Arch Linux:
       ```
-      sudo pacman -Sy meson ninja libgee gnome-menus vala glib2 gdk-pixbuf2 libwnck3 gtk3 xterm python python-wheel python-setuptools
+      sudo pacman -Sy meson ninja libgee gnome-menus vala glib2 gdk-pixbuf2 libwnck3 gtk3 python python-wheel python-setuptools
       ```
    2. Clone this repository into your machine
       ```
@@ -109,13 +109,13 @@ These lines appear in the **.desktop** files located in `/usr/share/applications
 * Templates added to make packages for Arch Linux (PKG) and Fedora (RPM)
 * Config files are introduced for project constants, replacing the hardcoded paths
 * Clean CSS code, some vars and unused functionality
-* New feature added: hide apps using a blacklist file.
+* New feature added: hide apps using a blocklist file.
 * The paths of background files are moved to `$HOME/.lightpad/`
 
 **Version 0.0.7**
 * Change indicator pages text for dots without animations
 * Fixed the CSS design of the searchbar that made it look cut on some screens
-* Implemented a new feature, now the black background is dynamic using an image if there exists
+* Implemented a new feature, you can use a image as background (dynamically detected if it's exists)
 * Added a new feature, now the apps are ordered alphabetically
 * Add SPEC and PKGBUILD files to make packages for Fedora and Arch Linux
 * Some bug fixing
@@ -124,7 +124,7 @@ These lines appear in the **.desktop** files located in `/usr/share/applications
 * Implemented the exact and standard way to open terminal apps
 * Improved meson postinstall script
 * Removed desktop environments detection to use the appropiate terminal
-* Added xterm as dependency for opening terminal apps
+* Added xterm as dependency for opening terminal apps ([deprecated](https://github.com/GNOME/glib/blob/cd1eba043c90da3aee8f5cd51b205b2e2c16f08e/gio/gdesktopappinfo.c#L2467-L2494))
 
 **Version 0.0.4**
 * Fix an important bug in the page indicators causing the wrong size obtained

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: meson,
                valac (>= 0.28.0),
                libgee-0.8-dev (>= 0.18.0),
                libgnome-menu-3-dev (>= 3.13.0),
-               libglib2.0-dev (>= 2.50.0),
+               libglib2.0-dev (>= 2.76.0),
                libgtk-3-dev (>= 3.22.0), 
                libwnck-3-dev (>= 3.20.0)
 Standards-Version: 4.1.1
@@ -19,10 +19,9 @@ Version: 0.0.8
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends},
          libc6,
-         libglib2.0-0 (>= 2.50.0),
+         libglib2.0-0 (>= 2.76.0),
          libgtk-3-0 (>= 3.22.0), 
          libgnome-menu-3-0 (>= 3.13.0),
          gnome-menus (>= 3.13.0),
-         libwnck-3-0 (>= 3.20.0),
-         xterm
+         libwnck-3-0 (>= 3.20.0)
 Description: LightPad is a lightweight, simple and powerful application launcher. Written in GTK+ 3.0. It is also Wayland compatible.

--- a/meson.build
+++ b/meson.build
@@ -53,7 +53,7 @@ executable(
     'src/Widgets/AppItem.vala',
     dependencies: [
         dependency('gio-unix-2.0', version: '>=2.56.0'),
-        dependency('glib-2.0', version: '>=2.56.0'),
+        dependency('glib-2.0', version: '>=2.76.0'),
         dependency('gtk+-3.0', version: '>=3.22'),
         dependency('gdk-3.0', version: '>=3.22.0'),
         dependency('cairo', version: '>=1.15.0'),

--- a/rpm-build.spec
+++ b/rpm-build.spec
@@ -1,12 +1,12 @@
 Name:        	lightpad   
-Version:        0.0.7
+Version:        0.0.8
 Release:        1
 Summary:        LightPad Launcher
 License:        GPL
 Group:		Utilities/System
 
 URL:            https://github.com/libredeb/lightpad
-Source0:        lightpad-0.0.7.tar.gz
+Source0:        lightpad-0.0.8.tar.gz
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build
 
 BuildRequires:  meson
@@ -31,7 +31,6 @@ Requires:	glib2
 Requires:	gnome-menus
 Requires:	gtk3
 Requires:	libwnck3
-Requires:   	xterm 
 
 %description
 LightPad is a lightweight, simple and powerful application launcher.
@@ -56,6 +55,7 @@ Written in GTK+ 3.0. It is also Wayland compatible.
 %{_datadir}/icons/hicolor/32x32/apps/lightpad.svg
 %{_datadir}/icons/hicolor/48x48/apps/lightpad.svg
 %{_datadir}/icons/hicolor/64x64/apps/lightpad.svg
+%{_datadir}/icons/hicolor/scalable/apps/application-default-icon.svg
 %{_datadir}/lightpad/application.css
 %{_datadir}/metainfo/com.github.libredeb.lightpad.appdata.xml
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -263,10 +263,11 @@ public class LightPadWindow : Widgets.CompositedWindow {
                         }
                         int app_index = (int) (child_index + (page_active * this.grid_y * this.grid_x));
 
-                        /* GTK+ implements open apps in terminal in this way:
-                         * https://github.com/GNOME/glib/blob/cd1eba043c90da3aee8f5cd51b205b2e2c16f08e/gio/gdesktopappinfo.c#L2467-L2494
-                         * So, if the desktop environment is not GNOME we need xterm as dependency
-                         * and the way to open apps in terminal is with the following code:
+                        /* GLib implements open apps in terminal in this way:
+                         * https://github.com/GNOME/glib/blob/2.76.0/gio/gdesktopappinfo.c#L2685
+                         * There's a major change in last versions of glib (from version 2.76.0 upwards)
+                         * So, xterm dependency it's no longer needed.
+                         * The way to open apps in terminal is with the following code:
                          */
                         if (this.filtered.get (app_index)["terminal"] == "true") {
                             GLib.AppInfo.create_from_commandline (this.filtered.get (app_index)["command"], null, GLib.AppInfoCreateFlags.NEEDS_TERMINAL).launch (null, null);


### PR DESCRIPTION
Upgraded glib2 dependency from 2.50 to 2.76.0 or higher and avoid xterm dependency