### PR TITLE
Add guess for budgie-desktop - closes #47

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -64,8 +64,8 @@ public class LightPadWindow : Widgets.CompositedWindow {
         monitor_dimensions.height = pixel_geo.height / monitor.get_scale_factor ();
 
         FileConfig config = new FileConfig(
-            monitor_dimensions.width, 
-            monitor_dimensions.height, 
+            monitor_dimensions.width,
+            monitor_dimensions.height,
             user_home + Resources.CONFIG_FILE
         );
         // For compatibility, maybe add FileConfig to LightPadWindow someday
@@ -76,9 +76,9 @@ public class LightPadWindow : Widgets.CompositedWindow {
         this.grid_y = config.grid_y;
         this.grid_x = config.grid_x;
 
-        message ("The monitor dimensions are: %dx%d", monitor_dimensions.width,  monitor_dimensions.height);
-        message ("The apps icon size is: %d", this.icon_size);
-        message ("The grid size are: %dx%d", this.grid_y, this.grid_x);
+        debug ("The monitor dimensions are: %dx%d", monitor_dimensions.width,  monitor_dimensions.height);
+        debug ("The apps icon size is: %d", this.icon_size);
+        debug ("The grid size are: %dx%d", this.grid_y, this.grid_x);
 
         // Window properties
         this.set_title ("LightPad");
@@ -89,7 +89,7 @@ public class LightPadWindow : Widgets.CompositedWindow {
         this.set_type_hint (Gdk.WindowTypeHint.NORMAL);
         //this.fullscreen (); <-- old method used
         var display = Gdk.Display.get_default();
-        message ("Amount of Monitors: %d", display.get_n_monitors ());
+        debug ("Amount of Monitors: %d", display.get_n_monitors ());
         int primary_monitor_number = 0;
         for (int i = 0; i < display.get_n_monitors (); i++) {
             if (get_display ().get_monitor (i).is_primary ()) {
@@ -117,7 +117,7 @@ public class LightPadWindow : Widgets.CompositedWindow {
 
         // Searchbar
         this.searchbar = new LightPad.Frontend.Searchbar ("Search");
-        message ("Searchbar created!");
+        debug ("Searchbar created!");
         this.searchbar.changed.connect (this.search);
 
         // Lateral distance (120 are the pixels of the searchbar width)
@@ -220,7 +220,7 @@ public class LightPadWindow : Widgets.CompositedWindow {
                 return true;
             }
         } );
-        
+
     }
 
     private void search() {
@@ -244,7 +244,7 @@ public class LightPadWindow : Widgets.CompositedWindow {
         for (int r = 0; r < this.grid_x; r++) {
             for (int c = 0; c < this.grid_y; c++) {
                 var item = new LightPad.Frontend.AppItem (
-                    this.icon_size, this.font_size, 
+                    this.icon_size, this.font_size,
                     this.item_box_width, this.item_box_height
                 );
                 this.children.append (item);
@@ -419,7 +419,7 @@ public class LightPadWindow : Widgets.CompositedWindow {
                 }
                 return true;
             case "BackSpace":
-                if (this.searchbar.text.length > 0) {   
+                if (this.searchbar.text.length > 0) {
                     this.searchbar.text = this.searchbar.text.slice (0, (int) this.searchbar.text.length - 1);
                 }
                 return true;

--- a/src/Config.vala
+++ b/src/Config.vala
@@ -89,10 +89,10 @@ class FileConfig : BaseConfig {
         try {
             config_f.load_from_file(file, KeyFileFlags.KEEP_COMMENTS);
         } catch {
-            message ("Config file not found. Using default values");
+            debug ("Config file not found. Using default values");
             return;
         }
-        
+
         const string[] group = {"Grid", "AppItem", "SearchBar"};
         try {
             merge_int(&grid_y, config_f.get_integer(group[0], "Y"));

--- a/src/DesktopEntries.vala
+++ b/src/DesktopEntries.vala
@@ -37,6 +37,9 @@ namespace LightPad.Backend {
                     case "sway":
                         guessed_prefix = "lxqt";
                         break;
+                    case "budgie-desktop":
+                        guessed_prefix = "gnome";
+                        break;
                     default:
                         guessed_prefix = lower;
                         break;
@@ -54,7 +57,7 @@ namespace LightPad.Backend {
 
             return "not-found";
         }
-    
+
         private static Gee.ArrayList<GMenu.TreeDirectory> get_categories () {
             var tree = new GMenu.Tree (resolve_menu_filename (), GMenu.TreeFlags.INCLUDE_EXCLUDED);
             try {
@@ -73,13 +76,13 @@ namespace LightPad.Backend {
                 }
                 item = iter.next ();
             }
-            message ("Number of categories: %d", main_directory_entries.size);
+            debug ("Number of categories: %d", main_directory_entries.size);
             return main_directory_entries;
         }
-        
+
         private static Gee.HashSet<GMenu.TreeEntry> get_applications_for_category (
             GMenu.TreeDirectory category) {
-            
+
             var entries = new Gee.HashSet<GMenu.TreeEntry>  (
                 (x) => ((GMenu.TreeEntry)x).get_desktop_file_path ().hash (),
                 (x,y) => ((GMenu.TreeEntry)x).get_desktop_file_path ().hash () == ((GMenu.TreeEntry)y).get_desktop_file_path ().hash ());
@@ -103,15 +106,15 @@ namespace LightPad.Backend {
                 }
                 item = iter.next ();
             }
-            message ("Category [%s] has [%d] apps", category.get_name (), entries.size);
+            debug ("Category [%s] has [%d] apps", category.get_name (), entries.size);
             return entries;
         }
-        
-        public static void enumerate_apps (Gee.HashMap<string, Gdk.Pixbuf> icons, 
+
+        public static void enumerate_apps (Gee.HashMap<string, Gdk.Pixbuf> icons,
                 int icon_size,
                 string user_home,
                 out Gee.ArrayList<Gee.HashMap<string, string>> list) {
-            
+
             var the_apps = new Gee.HashSet<GMenu.TreeEntry> (
                 (x) => ((GMenu.TreeEntry)x).get_desktop_file_path ().hash (),
                 (x,y) => ((GMenu.TreeEntry)x).get_desktop_file_path ().hash () == ((GMenu.TreeEntry)y).get_desktop_file_path ().hash ());
@@ -123,19 +126,19 @@ namespace LightPad.Backend {
                     the_apps.add(this_app);
                 }
             }
-            
-            message ("Amount of apps: %d", the_apps.size);
+
+            debug ("Amount of apps: %d", the_apps.size);
             var icon_theme = Gtk.IconTheme.get_default();
             list = new Gee.ArrayList<Gee.HashMap<string, string>> ();
-            
+
             var blocklist_file = GLib.File.new_for_path (user_home + Resources.BLOCKLIST_FILE);
             var apps_hidden = new Gee.ArrayList<string> ();
-            
+
             if (blocklist_file.query_exists ()) {
                 try {
                     var dis = new DataInputStream (blocklist_file.read ());
                     string line;
-            
+
                     while ((line = dis.read_line (null)) != null) {
                         apps_hidden.add (line);
                     }
@@ -145,18 +148,18 @@ namespace LightPad.Backend {
             } else {
                 apps_hidden.add ("");
             }
-            
+
             foreach (GMenu.TreeEntry entry in the_apps) {
                 var app = entry.get_app_info ();
-                if (app.get_nodisplay () == false && 
-                    app.get_is_hidden() == false && 
+                if (app.get_nodisplay () == false &&
+                    app.get_is_hidden() == false &&
                     app.get_icon() != null &&
                     !(app.get_commandline ().split (" ")[0] in apps_hidden))
                 {
                     var app_to_add = new Gee.HashMap<string, string> ();
                     app_to_add["name"] = app.get_display_name ();
                     app_to_add["description"] = app.get_description ();
-                    
+
                     // Needed to check further later if terminal is open in terminal (like VIM, HTop, etc.)
                     if (app.get_string ("Terminal") == "true") {
                         app_to_add["terminal"] = "true";
@@ -195,7 +198,7 @@ namespace LightPad.Backend {
             }
 
         }
-    
+
     }
 
 }


### PR DESCRIPTION
with budgie-desktop wayland the session is now purely "budgie-desktop" - but we use gnome-application-menu.  

This PR adds a guess to find the menu.  This resolves the seg fault.

I've done a bit of tidying changing 
 - "message" to debug since this is unnecessarily adding stuff to journalctl
 -  removing trailing spaces