### PR TITLE
fix: XDG menus file resolution

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -23,7 +23,7 @@ public class LightPadWindow : Widgets.CompositedWindow {
 
     public static string user_home = GLib.Environment.get_variable ("HOME");
     public Gee.ArrayList<Gee.HashMap<string, string>> apps = new Gee.ArrayList<Gee.HashMap<string, string>> ();
-    public Gee.HashMap<string, Gdk.Pixbuf> icons = new Gee.HashMap<string, Gdk.Pixbuf>();
+    public Gee.HashMap<string, Gdk.Pixbuf> icons = new Gee.HashMap<string, Gdk.Pixbuf> ();
     public Gee.ArrayList<Gee.HashMap<string, string>> filtered = new Gee.ArrayList<Gee.HashMap<string, string>> ();
     public LightPad.Frontend.Indicators pages;
 
@@ -500,6 +500,7 @@ static int main (string[] args) {
             main_window = new LightPadWindow ();
             main_window.set_application (app);
             main_window.show_all ();
+            Gtk.main ();
         } else {
             main_window.destroy ();
         }

--- a/src/DesktopEntries.vala
+++ b/src/DesktopEntries.vala
@@ -23,36 +23,52 @@ namespace LightPad.Backend {
 
     public class DesktopEntries : GLib.Object {
 
-        private static string resolve_menu_filename () {
-            var base_dir = Resources.XDG_MENU_DIR;
-            var desktop = GLib.Environment.get_variable ("XDG_SESSION_DESKTOP");
-            var lower = desktop.down ();
-            string guessed_prefix;
-
-            if (desktop != null && desktop != "") {
-                switch (lower) {
-                    case "kde":
-                        guessed_prefix = "kf5";
-                        break;
-                    case "sway":
-                        guessed_prefix = "lxqt";
-                        break;
-                    default:
-                        guessed_prefix = lower;
-                        break;
-                }
-
-                var guessed_menu = guessed_prefix + "-applications.menu";
-                if (GLib.File.new_for_path (base_dir + guessed_menu).query_exists ()) {
-                    return guessed_menu;
-                }
-            } else if (GLib.File.new_for_path (base_dir + Resources.XDG_FALLBACK_MENU).query_exists ()) {
-                return Resources.XDG_FALLBACK_MENU;
-            } else {
-                error ("No %s XDG menu file found, verify the file", base_dir + lower + "-applications.menu exists");
+        public static string? try_resolve(string? value, Gee.HashMap<string, string> map) {
+            if (value == null) {
+                return null;
             }
 
-            return "not-found";
+            foreach (var part in value.down ().split (":")) {
+                var trimmed = part.strip ();
+                if (map.has_key (trimmed)) {
+                    return map.get (trimmed);
+                }
+            }
+
+            return null;
+        }
+
+        private static string resolve_menu_filename () {
+            var desktop_menus_map = new Gee.HashMap<string, string> ();
+
+            desktop_menus_map.set ("gnome", "gnome-applications.menu");
+            desktop_menus_map.set ("unity", "gnome-applications.menu");
+            desktop_menus_map.set ("kde", "kf5-applications.menu");
+            desktop_menus_map.set ("plasma", "plasma-applications.menu");
+            desktop_menus_map.set ("xfce", "xfce-applications.menu");
+            desktop_menus_map.set ("x-cinnamon", "cinnamon-applications.menu");
+            desktop_menus_map.set ("cinnamon", "cinnamon-applications.menu");
+            desktop_menus_map.set ("mate", "mate-applications.menu");
+            desktop_menus_map.set ("lxde", "lxde-applications.menu");
+            desktop_menus_map.set ("lxqt", "lxqt-applications.menu");
+            desktop_menus_map.set ("sway", "lxqt-applications.menu");
+            desktop_menus_map.set ("budgie", "gnome-applications.menu");
+            desktop_menus_map.set ("budgie-desktop", "gnome-applications.menu");
+            desktop_menus_map.set ("pantheon", "pantheon-applications.menu");
+
+            string? current_desktop = GLib.Environment.get_variable ("XDG_CURRENT_DESKTOP");
+            string? resolved = try_resolve (current_desktop, desktop_menus_map);
+            if (resolved != null) {
+                return resolved;
+            }
+
+            string? session_desktop = GLib.Environment.get_variable ("XDG_SESSION_DESKTOP");
+            resolved = try_resolve (session_desktop, desktop_menus_map);
+            if (resolved != null) {
+                return resolved;
+            }
+
+            return Resources.XDG_FALLBACK_MENU;
         }
     
         private static Gee.ArrayList<GMenu.TreeDirectory> get_categories () {

--- a/src/Resources.vala
+++ b/src/Resources.vala
@@ -26,6 +26,5 @@ namespace Resources {
      public const string LIGHTPAD_CONFIG_DIR = "/." + Config.PROJECT_NAME;
      public const string BLOCKLIST_FILE = LIGHTPAD_CONFIG_DIR + "/blocklist";
      public const string CONFIG_FILE = LIGHTPAD_CONFIG_DIR + "/config";
-     public const string XDG_MENU_DIR = "/etc/xdg/menus/";
      public const string XDG_FALLBACK_MENU = "applications.menu";
 }


### PR DESCRIPTION
- some desktop as cinnamon has a different value for `XDG_CURRENT_DESKTOP`
- improved applications menu file resolution for more desktop environments
- removed unneeded variable and code