### PR TITLE
fix: update deprecated code

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -108,7 +108,7 @@ public class LightPadWindow : Widgets.CompositedWindow {
             // We want to consume this event so the parent window's handler doesn't see it.
             // This will prevent the Lightpad from closing when clicked on the searchbar.
             // You might want to add specific logic for the searchbar here (e.g., focus it).
-            
+
             // For now, just consume the event.
             return true; // Return true to stop event propagation (consume the event)
         });
@@ -190,7 +190,7 @@ public class LightPadWindow : Widgets.CompositedWindow {
             });
             return true;
         } );
-        
+
         // close Lightpad when we clic on empty area (original code block, slightly adjusted)
         this.button_release_event.connect ( (widget, event) => {
             double event_x = event.x;
@@ -205,21 +205,22 @@ public class LightPadWindow : Widgets.CompositedWindow {
             int searchbar_width = searchbar_allocation.width;
             int searchbar_height = searchbar_allocation.height;
 
-            bool clicked_inside_searchbar = (x_relative_to_searchbar >= 0 && x_relative_to_searchbar <= searchbar_width) && 
-                                            (y_relative_to_searchbar >= 0 && y_relative_to_searchbar <= searchbar_height);
+            bool clicked_inside_searchbar =
+                (x_relative_to_searchbar >= 0 && x_relative_to_searchbar <= searchbar_width) &&
+                (y_relative_to_searchbar >= 0 && y_relative_to_searchbar <= searchbar_height);
 
             if (clicked_inside_searchbar) {
                 // If click was inside searchbar, do nothing here. The searchbar's own handler
                 // should have already consumed the event by returning 'true'.
                 // This 'false' here allows other potential parent handlers (unlikely in this case)
                 // to still see the event, but the searchbar itself already consumed it.
-                return false; 
+                return false;
             } else {
                 // If click was outside searchbar, hide Lightpad
                 this.hide ();
                 GLib.Timeout.add_seconds (1, () => {
                     this.destroy ();
-                    return GLib.Source.REMOVE; 
+                    return GLib.Source.REMOVE;
                 });
                 return true; // Consume the event here to prevent further propagation after hide
             }
@@ -417,20 +418,20 @@ public class LightPadWindow : Widgets.CompositedWindow {
                 double offset_y = (widget_size.height - scaled_image_height) / 2.0;
 
                 // Save the current state of the Cairo context before transformations
-                context.save();
+                context.save ();
 
                 // Apply translation to center the image
-                context.translate(offset_x, offset_y);
-                
+                context.translate (offset_x, offset_y);
+
                 // Apply scaling
-                context.scale(scale_factor, scale_factor);
+                context.scale (scale_factor, scale_factor);
 
                 // Set the pixbuf as the source and paint it
                 Gdk.cairo_set_source_pixbuf (context, image_pf, 0, 0);
                 context.paint ();
 
                 // Restore the context to its original state (undo translate/scale)
-                context.restore();
+                context.restore ();
             } else { // Is PNG image
                 context.scale (factor_scaling, factor_scaling);
                 context.set_source (pattern);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -103,6 +103,15 @@ public class LightPadWindow : Widgets.CompositedWindow {
         this.searchbar = new LightPad.Frontend.Searchbar ("Search");
         debug ("Searchbar created!");
         this.searchbar.changed.connect (this.search);
+        this.searchbar.button_release_event.connect ((sbar_widget, sbar_event) => {
+            // This event handler is for clicks directly on the searchbar itself.
+            // We want to consume this event so the parent window's handler doesn't see it.
+            // This will prevent the Lightpad from closing when clicked on the searchbar.
+            // You might want to add specific logic for the searchbar here (e.g., focus it).
+            
+            // For now, just consume the event.
+            return true; // Return true to stop event propagation (consume the event)
+        });
 
         // Lateral distance (120 are the pixels of the searchbar width)
         int screen_half = (monitor_dimensions.width / 2) - 120;
@@ -159,8 +168,6 @@ public class LightPadWindow : Widgets.CompositedWindow {
             this.dynamic_background = true;
             try {
                 image_pf = new Gdk.Pixbuf.from_file (file_jpg);
-                int w = image_pf.get_width ();
-                factor_scaling = (double) ((double) ((monitor_dimensions.width * 100) / w) / 100);
             } catch (GLib.Error e) {
                 warning ("Cant create Pixbuf background!");
             }
@@ -183,25 +190,38 @@ public class LightPadWindow : Widgets.CompositedWindow {
             });
             return true;
         } );
-        // close Lightpad when we clic on empty area
-        this.button_release_event.connect ( () => {
-            // for some reason, the searchbar widget is part of the main_window (this)
-            // widget. So we can not check if the searchbar is focused or not. So this
-            // is a workaround based on the searchbar dimmensions and clicked position
-            // based on this widget.
-            int x, y;
-            int w, h;
-            this.searchbar.get_pointer (out x, out y);
-            this.searchbar.get_size_request (out w, out h);
-            if (( (x <= w) && (x >= 0) ) && ( (y <= h) && (y >= 0) )) {
-                return false;
+        
+        // close Lightpad when we clic on empty area (original code block, slightly adjusted)
+        this.button_release_event.connect ( (widget, event) => {
+            double event_x = event.x;
+            double event_y = event.y;
+
+            Gtk.Allocation searchbar_allocation;
+            this.searchbar.get_allocation (out searchbar_allocation);
+
+            double x_relative_to_searchbar = event_x - searchbar_allocation.x;
+            double y_relative_to_searchbar = event_y - searchbar_allocation.y;
+
+            int searchbar_width = searchbar_allocation.width;
+            int searchbar_height = searchbar_allocation.height;
+
+            bool clicked_inside_searchbar = (x_relative_to_searchbar >= 0 && x_relative_to_searchbar <= searchbar_width) && 
+                                            (y_relative_to_searchbar >= 0 && y_relative_to_searchbar <= searchbar_height);
+
+            if (clicked_inside_searchbar) {
+                // If click was inside searchbar, do nothing here. The searchbar's own handler
+                // should have already consumed the event by returning 'true'.
+                // This 'false' here allows other potential parent handlers (unlikely in this case)
+                // to still see the event, but the searchbar itself already consumed it.
+                return false; 
             } else {
+                // If click was outside searchbar, hide Lightpad
                 this.hide ();
                 GLib.Timeout.add_seconds (1, () => {
                     this.destroy ();
-                    return GLib.Source.REMOVE;
+                    return GLib.Source.REMOVE; 
                 });
-                return true;
+                return true; // Consume the event here to prevent further propagation after hide
             }
         } );
 
@@ -368,18 +388,54 @@ public class LightPadWindow : Widgets.CompositedWindow {
     }
 
     private bool draw_background (Gtk.Widget widget, Cairo.Context ctx) {
-        var context = Gdk.cairo_create (widget.get_window ());
+        // Use the Cairo context provided by GTK
+        var context = ctx;
+
+        Gtk.Allocation widget_size;
+        // Get the allocation (size and position) of the widget/window being drawn
+        widget.get_allocation (out widget_size);
 
         if (this.dynamic_background) {
             if (image_pf != null) { // If JPG exist, prefer this
-                context.scale (factor_scaling, factor_scaling);
+                double image_width = (double) image_pf.width;
+                double image_height = (double) image_pf.height;
+
+                // Calculate scaling factors to fill the widget area
+                double scale_x = widget_size.width / image_width;
+                double scale_y = widget_size.height / image_height;
+
+                // Use the larger scale factor to ensure the image covers the entire widget (aspect fill)
+                // Ternary expression for Math.Max
+                double scale_factor = (scale_x > scale_y) ? scale_x : scale_y;
+
+                // Calculate the dimensions of the scaled image
+                double scaled_image_width = image_width * scale_factor;
+                double scaled_image_height = image_height * scale_factor;
+
+                // Calculate offsets to center the scaled image within the widget
+                double offset_x = (widget_size.width - scaled_image_width) / 2.0;
+                double offset_y = (widget_size.height - scaled_image_height) / 2.0;
+
+                // Save the current state of the Cairo context before transformations
+                context.save();
+
+                // Apply translation to center the image
+                context.translate(offset_x, offset_y);
+                
+                // Apply scaling
+                context.scale(scale_factor, scale_factor);
+
+                // Set the pixbuf as the source and paint it
                 Gdk.cairo_set_source_pixbuf (context, image_pf, 0, 0);
+                context.paint ();
+
+                // Restore the context to its original state (undo translate/scale)
+                context.restore();
             } else { // Is PNG image
                 context.scale (factor_scaling, factor_scaling);
                 context.set_source (pattern);
+                context.paint (); // Paint the PNG here
             }
-
-            context.paint ();
         } else {
             // Semi-dark background
             Gtk.Allocation size;

--- a/src/Config.vala
+++ b/src/Config.vala
@@ -81,24 +81,24 @@ class FileConfig : BaseConfig {
 
     private GLib.KeyFile config_f;
     private ConfigField[] config_fields;
-    private const string[] groups = {"Grid", "AppItem", "SearchBar"};
+    private const string[] GROUPS = {"Grid", "AppItem", "SearchBar"};
 
     public FileConfig (int screen_width, int screen_height, string file) {
         base (screen_width, screen_height);
 
         config_fields = {
-            { groups[0], "Y", ConfigType.INT, &grid_y },
-            { groups[0], "X", ConfigType.INT, &grid_x },
-            { groups[0], "RowSpacing", ConfigType.INT, &grid_row_spacing },
-            { groups[0], "ColumnSpacing", ConfigType.INT, &grid_col_spacing },
+            { GROUPS[0], "Y", ConfigType.INT, &grid_y },
+            { GROUPS[0], "X", ConfigType.INT, &grid_x },
+            { GROUPS[0], "RowSpacing", ConfigType.INT, &grid_row_spacing },
+            { GROUPS[0], "ColumnSpacing", ConfigType.INT, &grid_col_spacing },
 
-            { groups[1], "FontSize", ConfigType.DOUBLE, &item_font_size },
-            { groups[1], "IconSize", ConfigType.INT, &item_icon_size },
-            { groups[1], "BoxWidth", ConfigType.INT, &item_box_width },
-            { groups[1], "BoxHeight", ConfigType.INT, &item_box_height },
+            { GROUPS[1], "FontSize", ConfigType.DOUBLE, &item_font_size },
+            { GROUPS[1], "IconSize", ConfigType.INT, &item_icon_size },
+            { GROUPS[1], "BoxWidth", ConfigType.INT, &item_box_width },
+            { GROUPS[1], "BoxHeight", ConfigType.INT, &item_box_height },
 
-            { groups[2], "Width", ConfigType.INT, &sb_width },
-            { groups[2], "Height", ConfigType.INT, &sb_height },
+            { GROUPS[2], "Width", ConfigType.INT, &sb_width },
+            { GROUPS[2], "Height", ConfigType.INT, &sb_height },
         };
 
         config_f = new GLib.KeyFile ();
@@ -117,12 +117,12 @@ class FileConfig : BaseConfig {
                     case ConfigType.INT:
                         int val_i = config_f.get_integer (field.group, field.key);
                         if (val_i > -1)
-                            *((int*) field.pointer) = val_i;
+                            * ((int*) field.pointer) = val_i;
                         break;
                     case ConfigType.DOUBLE:
                         double val_d = config_f.get_double (field.group, field.key);
                         if (val_d > -1.0)
-                            *((double*) field.pointer) = val_d;
+                            * ((double*) field.pointer) = val_d;
                         break;
                 }
             } catch (GLib.Error e) {
@@ -136,10 +136,10 @@ class FileConfig : BaseConfig {
         foreach (var field in config_fields) {
             switch (field.type) {
                 case ConfigType.INT:
-                    keyfile.set_integer (field.group, field.key, *((int*) field.pointer));
+                    keyfile.set_integer (field.group, field.key, * ((int*) field.pointer));
                     break;
                 case ConfigType.DOUBLE:
-                    keyfile.set_double (field.group, field.key, *((double*) field.pointer));
+                    keyfile.set_double (field.group, field.key, * ((double*) field.pointer));
                     break;
             }
         }

--- a/src/Utilities.vala
+++ b/src/Utilities.vala
@@ -23,7 +23,9 @@ namespace LightPad.Frontend {
 
             double max_possible_radius_h = width / 2.0;
             double max_possible_radius_v = height / 2.0;
-            double max_possible_radius = (max_possible_radius_h < max_possible_radius_v) ? max_possible_radius_h : max_possible_radius_v;
+            double max_possible_radius =
+                (max_possible_radius_h < max_possible_radius_v) ?
+                max_possible_radius_h : max_possible_radius_v;
 
             // Make sure the radius is no greater than half the width or height
             // to avoid irregular shapes

--- a/src/Utilities.vala
+++ b/src/Utilities.vala
@@ -11,29 +11,57 @@ namespace LightPad.Frontend {
 
     class Utilities : GLib.Object {
 
-        public static void draw_rounded_rectangle (Cairo.Context context, double radius,
-                                                  double offset, Gtk.Allocation size) {
-            context.move_to (size.x + radius, size.y + offset);
+        public static void draw_rounded_rectangle (
+            Cairo.Context context, double radius, double offset, Gtk.Allocation size
+        ) {
+            // The coordinates are now relative to the top-left corner of the widget.
+            // Defines the drawing limits adjusted by the offset
+            double x_start = offset;
+            double y_start = offset;
+            double width = size.width - (2 * offset);
+            double height = size.height - (2 * offset);
+
+            double max_possible_radius_h = width / 2.0;
+            double max_possible_radius_v = height / 2.0;
+            double max_possible_radius = (max_possible_radius_h < max_possible_radius_v) ? max_possible_radius_h : max_possible_radius_v;
+
+            // Make sure the radius is no greater than half the width or height
+            // to avoid irregular shapes
+            radius = (radius < max_possible_radius) ? radius : max_possible_radius;
+
+            // Move to the starting point for the first arc
+            context.move_to (x_start + radius, y_start);
+
+            // Upper right edge
             context.arc (
-                size.x + size.width - radius - offset,
-                size.y + radius + offset,
+                x_start + width - radius,
+                y_start + radius,
                 radius, Math.PI * 1.5, Math.PI * 2
             );
+
+            // Lower right corner
             context.arc (
-                size.x + size.width - radius - offset,
-                size.y + size.height - radius - offset,
+                x_start + width - radius,
+                y_start + height - radius,
                 radius, 0, Math.PI * 0.5
             );
+
+            // Lower left arc
             context.arc (
-                size.x + radius + offset,
-                size.y + size.height - radius - offset,
+                x_start + radius,
+                y_start + height - radius,
                 radius, Math.PI * 0.5, Math.PI
             );
+
+            // Upper left curve
             context.arc (
-                size.x + radius + offset,
-                size.y + radius + offset,
+                x_start + radius,
+                y_start + radius,
                 radius, Math.PI, Math.PI * 1.5
             );
+
+            // Close the path to form the complete rounded rectangle.
+            context.close_path ();
         }
 
         public static LightPad.Frontend.Color average_color (Gdk.Pixbuf source) {

--- a/src/Widgets/AppItem.vala
+++ b/src/Widgets/AppItem.vala
@@ -86,26 +86,43 @@ namespace LightPad.Frontend {
         private bool draw_icon (Gtk.Widget widget, Cairo.Context ctx) {
             Gtk.Allocation size;
             widget.get_allocation (out size);
-            var context = Gdk.cairo_create (widget.get_window ());
+            var context = ctx;
 
-            // Draw icon
-            Gdk.cairo_set_source_pixbuf (context, this.icon, size.x + ((this.icon.width - size.width) / -2.0), size.y);
+            /* 
+             * The context is already set so that (0,0) is the top left corner of the widget.
+             * Calculate the horizontal center for the icon.
+             * The Y position of the icon is 0 (above the widget).
+             */
+            double icon_x = (size.width - this.icon.width) / 2.0;
+            double icon_y = 0.0;
+
+            // Draw the icon
+            // The coordinates are relative to the widget origin (0,0).
+            Gdk.cairo_set_source_pixbuf (context, this.icon, icon_x, icon_y);
             context.paint ();
 
-            // Truncate text
             Cairo.TextExtents extents;
             context.select_font_face ("Sans", Cairo.FontSlant.NORMAL, Cairo.FontWeight.NORMAL);
             context.set_font_size (this.font_size);
             LightPad.Frontend.Utilities.truncate_text (context, size, 10, this.label, out this.label, out extents);
 
-            // Draw text shadow
-            context.move_to ((size.x + size.width / 2 - extents.width / 2) + 1, (size.y + size.height - 10) + 1);
+            /*
+             * Calculate the coordinates for the text.
+             * Here, (size.width / 2 - extents.width / 2) is already the horizontal center relative to the widget.
+             * For the Y position, if we want it to be 10px from the bottom edge, it would be size.height - 10.
+             */
+            double text_x_center = size.width / 2 - extents.width / 2;
+            double text_y_base = size.height - 10; // 10px desde el borde inferior
+
+            // Draw the shadow of the text
+            // Add 1 to X and Y for a slight shadow offset.
+            context.move_to (text_x_center + 1, text_y_base + 1);
             context.set_source_rgba (0.0, 0.0, 0.0, 0.8);
             context.show_text (this.label);
 
             // Draw normal text
             context.set_source_rgba (1.0, 1.0, 1.0, 1.0);
-            context.move_to (size.x + size.width / 2 - extents.width / 2, size.y + size.height - 10);
+            context.move_to (text_x_center, text_y_base);
             context.show_text (this.label);
 
             return false;
@@ -114,7 +131,7 @@ namespace LightPad.Frontend {
         private bool draw_background (Gtk.Widget widget, Cairo.Context ctx) {
             Gtk.Allocation size;
             widget.get_allocation (out size);
-            var context = Gdk.cairo_create (widget.get_window ());
+            var context = ctx;
 
             double progress;
             if (this.current_frame > 1) {

--- a/src/Widgets/Indicators.vala
+++ b/src/Widgets/Indicators.vala
@@ -111,53 +111,57 @@ namespace LightPad.Frontend {
         }
 
         protected bool draw_background (Gtk.Widget widget, Cairo.Context ctx) {
-            Gtk.Allocation size;
+            Gtk.Allocation size; // Allocation of the pager widget itself (parent)
             widget.get_allocation (out size);
-            var context = Gdk.cairo_create (widget.get_window ());
-
-
+            var context = ctx;
+        
             double d = (double) this.animation_frames;
             double t = (double) this.current_frame;
-
-            double progress;
-
+        
             // easeOutQuint algorithm - aka - start normal end slow
-            progress = ((t = t / d - 1) * t * t * t * t + 1);
-
-            // Get allocations of old rectangle
+            double progress = ((t = t / d - 1) * t * t * t * t + 1);
+        
             Gtk.Allocation size_old, size_new;
+            
+            // Ensure indices are valid to prevent crashes
+            if (this.old_active < 0 || this.old_active >= this.get_children().length () ||
+                this.active < 0 || this.active >= this.get_children().length ()) {
+                // Fallback or just return if indices are out of bounds
+                // Consider drawing a default state here or logging an error.
+                return false;
+            }
+        
+            // Get allocations of the old and new active child widgets (page indicators)
+            // These allocations are relative to the parent of the pager widget.
             this.get_children ().nth_data (this.old_active).get_allocation (out size_old);
-
-            // Get allocations for the new rectangle
             this.get_children ().nth_data (this.active).get_allocation (out size_new);
-
-            // Move and make a new rectangle, according to progress
-            double x = size_old.x + (size_new.x - (double) size_old.x) * progress;
-            double y = size_old.y + (size_new.y - (double) size_old.y);
-            double width = size_old.width + (size_new.width - (double) size_old.width) * progress;
-            double height = size_old.height + (size_new.height - (double) size_old.height);
-
-            double offset = 2.0; //  old: 7.0
-            double radius = 6.0; // old: 12.0
-
-            context.set_source_rgba (1.0, 1.0, 1.0, 1.0); // white background color
-            context.move_to (x + radius, size.y + offset);
-            // old code 
-            /* // Draw outside black stroke
-            context.set_source_rgba (0.1, 0.1, 0.1, 1.0);
-            context.move_to (x + radius + 1, size.y + offset + 1);
-            context.arc (x + width - radius - offset, size.y + size.height - radius - (offset / 2), radius, 0, Math.PI * 2);
-            context.set_line_width (1.0);
-            context.stroke ();
-                context.arc (x + width - radius - offset, size.y + size.height - radius - (offset / 2), radius, 0, Math.PI * 2);
-                */
-            context.arc (x + width / 2, y + height / 2, radius, 0, Math.PI * 2);
+        
+            // Calculate child positions relative to the pager widget's own origin (0,0) for the Cairo context.
+            // This removes the "global" offset from size_old.x/y and size_new.x/y.
+            double x_old_relative = size_old.x - size.x;
+            double y_old_relative = size_old.y - size.y;
+        
+            double x_new_relative = size_new.x - size.x;
+            double y_new_relative = size_new.y - size.y;
+        
+            // Calculate the animated position and size of the indicator,
+            // relative to the pager widget's drawing context.
+            double x_animated_relative = x_old_relative + (x_new_relative - x_old_relative) * progress;
+            double y_animated_relative = y_old_relative + (y_new_relative - y_old_relative); // Assuming Y doesn't animate or y_old_relative == y_new_relative
+            double width_animated = size_old.width + (size_new.width - (double) size_old.width) * progress;
+            double height_animated = size_old.height + (size_new.height - (double) size_old.height);
+        
+            double radius = 6.0;
+        
+            // Set the drawing color to white (fully opaque)
+            context.set_source_rgba (1.0, 1.0, 1.0, 1.0);
+        
+            // Draw the animated circle (filled)
+            // The center of the circle is calculated based on the animated allocation.
+            context.arc (x_animated_relative + width_animated / 2.0, y_animated_relative + height_animated / 2.0, radius, 0, Math.PI * 2);
             context.fill ();
-
+        
             return false;
         }
-
-
     }
-
 }

--- a/src/Widgets/Indicators.vala
+++ b/src/Widgets/Indicators.vala
@@ -114,53 +114,57 @@ namespace LightPad.Frontend {
             Gtk.Allocation size; // Allocation of the pager widget itself (parent)
             widget.get_allocation (out size);
             var context = ctx;
-        
+
             double d = (double) this.animation_frames;
             double t = (double) this.current_frame;
-        
+
             // easeOutQuint algorithm - aka - start normal end slow
             double progress = ((t = t / d - 1) * t * t * t * t + 1);
-        
+
             Gtk.Allocation size_old, size_new;
-            
+
             // Ensure indices are valid to prevent crashes
-            if (this.old_active < 0 || this.old_active >= this.get_children().length () ||
-                this.active < 0 || this.active >= this.get_children().length ()) {
+            if (this.old_active < 0 || this.old_active >= this.get_children ().length () ||
+                this.active < 0 || this.active >= this.get_children ().length ()) {
                 // Fallback or just return if indices are out of bounds
                 // Consider drawing a default state here or logging an error.
                 return false;
             }
-        
+
             // Get allocations of the old and new active child widgets (page indicators)
             // These allocations are relative to the parent of the pager widget.
             this.get_children ().nth_data (this.old_active).get_allocation (out size_old);
             this.get_children ().nth_data (this.active).get_allocation (out size_new);
-        
+
             // Calculate child positions relative to the pager widget's own origin (0,0) for the Cairo context.
             // This removes the "global" offset from size_old.x/y and size_new.x/y.
             double x_old_relative = size_old.x - size.x;
             double y_old_relative = size_old.y - size.y;
-        
+
             double x_new_relative = size_new.x - size.x;
             double y_new_relative = size_new.y - size.y;
-        
+
             // Calculate the animated position and size of the indicator,
             // relative to the pager widget's drawing context.
             double x_animated_relative = x_old_relative + (x_new_relative - x_old_relative) * progress;
             double y_animated_relative = y_old_relative + (y_new_relative - y_old_relative); // Assuming Y doesn't animate or y_old_relative == y_new_relative
             double width_animated = size_old.width + (size_new.width - (double) size_old.width) * progress;
             double height_animated = size_old.height + (size_new.height - (double) size_old.height);
-        
+
             double radius = 6.0;
-        
+
             // Set the drawing color to white (fully opaque)
             context.set_source_rgba (1.0, 1.0, 1.0, 1.0);
-        
+
             // Draw the animated circle (filled)
             // The center of the circle is calculated based on the animated allocation.
-            context.arc (x_animated_relative + width_animated / 2.0, y_animated_relative + height_animated / 2.0, radius, 0, Math.PI * 2);
+            context.arc (
+                x_animated_relative + width_animated / 2.0,
+                y_animated_relative + height_animated / 2.0,
+                radius, 0, Math.PI * 2
+            );
             context.fill ();
-        
+
             return false;
         }
     }


### PR DESCRIPTION
- Updated 4 ocurrences of `Gdk.cairo_create` that have been deprecated since 3.22
- Updated an ocurrence of `Gtk.Widget.get_pointer` that have been deprecated since 3.4
- Now the JPG background are resized to fit to entire screen