### PR TITLE
Fix/startup gamepad directions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,20 @@ project(
 )
 
 PROJECT_NAME = 'lightpad'
+
+# Append short git commit hash to project version
+git = find_program('git', required: false)
+if git.found()
+  git_cmd = run_command(git, 'rev-parse', '--short', 'HEAD', check: false)
+  if git_cmd.returncode() == 0
+    project_version = meson.project_version() + '-' + git_cmd.stdout().strip()
+  else
+    project_version = meson.project_version()
+  endif
+else
+  project_version = meson.project_version()
+endif
+
 prefix = get_option('prefix')
 libdir = join_paths(prefix, get_option('libdir'))
 datadir = join_paths(prefix, get_option('datadir'))
@@ -20,7 +34,7 @@ conf = configuration_data()
 conf.set_quoted('PROJECT_NAME', PROJECT_NAME)
 conf.set_quoted('PACKAGE_LIBDIR', libdir)
 conf.set_quoted('PACKAGE_SHAREDIR', datadir)
-conf.set_quoted('PACKAGE_VERSION', meson.project_version())
+conf.set_quoted('PACKAGE_VERSION', project_version)
 
 config_h = configure_file(
 	output: 'config.h',

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -209,25 +209,28 @@ public class LightPadWindow : Widgets.CompositedWindow {
                                     case SDL.Input.GameController.Button.A:
                                     case SDL.Input.GameController.Button.B:
                                         if (this.filtered.size >= 1) {
-                                            var focused_widget = this.get_focus ();
-                                            if (focused_widget != null) {
-                                                focused_widget.button_release_event (
-                                                    (Gdk.EventButton) new Gdk.Event (Gdk.EventType.BUTTON_PRESS)
-                                                );
-                                            }
+                                            GLib.Idle.add (() => {
+                                                var focused_widget = this.get_focus ();
+                                                if (focused_widget != null) {
+                                                    focused_widget.button_release_event (
+                                                        (Gdk.EventButton) new Gdk.Event (Gdk.EventType.BUTTON_PRESS)
+                                                    );
+                                                }
+                                                return false;
+                                            });
                                         }
                                         break;
                                     case SDL.Input.GameController.Button.DPAD_UP:
-                                        this.do_up ();
+                                        GLib.Idle.add (() => { this.do_up (); return false; });
                                         break;
                                     case SDL.Input.GameController.Button.DPAD_DOWN:
-                                        this.do_down ();
+                                        GLib.Idle.add (() => { this.do_down (); return false; });
                                         break;
                                     case SDL.Input.GameController.Button.DPAD_LEFT:
-                                        this.do_left ();
+                                        GLib.Idle.add (() => { this.do_left (); return false; });
                                         break;
                                     case SDL.Input.GameController.Button.DPAD_RIGHT:
-                                        this.do_right ();
+                                        GLib.Idle.add (() => { this.do_right (); return false; });
                                         break;
                                     default:
                                         break;
@@ -241,20 +244,20 @@ public class LightPadWindow : Widgets.CompositedWindow {
                                 // Horizontal axis (left stick)
                                 if (axis == SDL.Input.GameController.Axis.LEFTX) {
                                     if (value < -AXIS_DEAD_ZONE && (now - last_axis_h_move > AXIS_THROTTLE_MS)) {
-                                        this.do_left ();
+                                        GLib.Idle.add (() => { this.do_left (); return false; });
                                         last_axis_h_move = now;
                                     } else if (value > AXIS_DEAD_ZONE && (now - last_axis_h_move > AXIS_THROTTLE_MS)) {
-                                        this.do_right ();
+                                        GLib.Idle.add (() => { this.do_right (); return false; });
                                         last_axis_h_move = now;
                                     }
                                 }
                                 // Vertical axis (left stick)
                                 if (axis == SDL.Input.GameController.Axis.LEFTY) {
                                     if (value < -AXIS_DEAD_ZONE && (now - last_axis_v_move > AXIS_THROTTLE_MS)) {
-                                        this.do_up ();
+                                        GLib.Idle.add (() => { this.do_up (); return false; });
                                         last_axis_v_move = now;
                                     } else if (value > AXIS_DEAD_ZONE && (now - last_axis_v_move > AXIS_THROTTLE_MS)) {
-                                        this.do_down ();
+                                        GLib.Idle.add (() => { this.do_down (); return false; });
                                         last_axis_v_move = now;
                                     }
                                 }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -155,6 +155,7 @@ public class LightPadWindow : Widgets.CompositedWindow {
                     new Gdk.Cursor.for_display (display, Gdk.CursorType.BLANK_CURSOR)
                 );
             }
+            this.children.nth_data (0).grab_focus ();
         });
 
         // Signals and callbacks

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -155,7 +155,14 @@ public class LightPadWindow : Widgets.CompositedWindow {
                     new Gdk.Cursor.for_display (display, Gdk.CursorType.BLANK_CURSOR)
                 );
             }
-            this.children.nth_data (0).grab_focus ();
+
+            // A short delay before grabbing focus to ensure the window manager has processed the window.
+            // This helps in scenarios where the app starts at boot and might lose focus.
+            GLib.Timeout.add (500, () => {
+                this.present ();
+                this.children.nth_data (0).grab_focus ();
+                return false; // Do not repeat
+            });
         });
 
         // Signals and callbacks

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -454,6 +454,7 @@ public class LightPadWindow : Widgets.CompositedWindow {
 
         if (pos_x - 1 >= 0) {
             this.grid.get_child_at (pos_x - 1, pos_y).grab_focus ();
+            this.queue_draw ();
         }
 
         if (current_item % this.grid_y == this.grid_y - 1) {
@@ -471,6 +472,7 @@ public class LightPadWindow : Widgets.CompositedWindow {
 
         if (pos_x + 1 < this.grid_x) {
             this.grid.get_child_at (pos_x + 1, pos_y).grab_focus ();
+            this.queue_draw ();
         }
 
         if (current_item % this.grid_y == 0) {
@@ -488,6 +490,7 @@ public class LightPadWindow : Widgets.CompositedWindow {
 
         if (pos_y - 1 >= 0) {
             this.grid.get_child_at (pos_x, pos_y - 1).grab_focus ();
+            this.queue_draw ();
         }
         return true;
     }
@@ -502,6 +505,7 @@ public class LightPadWindow : Widgets.CompositedWindow {
 
         if (pos_y + 1 < this.grid_y) {
             this.grid.get_child_at (pos_x, pos_y + 1).grab_focus ();
+            this.queue_draw ();
         }
 
         return true;

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -454,7 +454,6 @@ public class LightPadWindow : Widgets.CompositedWindow {
 
         if (pos_x - 1 >= 0) {
             this.grid.get_child_at (pos_x - 1, pos_y).grab_focus ();
-            this.queue_draw ();
         }
 
         if (current_item % this.grid_y == this.grid_y - 1) {
@@ -472,7 +471,6 @@ public class LightPadWindow : Widgets.CompositedWindow {
 
         if (pos_x + 1 < this.grid_x) {
             this.grid.get_child_at (pos_x + 1, pos_y).grab_focus ();
-            this.queue_draw ();
         }
 
         if (current_item % this.grid_y == 0) {
@@ -490,7 +488,6 @@ public class LightPadWindow : Widgets.CompositedWindow {
 
         if (pos_y - 1 >= 0) {
             this.grid.get_child_at (pos_x, pos_y - 1).grab_focus ();
-            this.queue_draw ();
         }
         return true;
     }
@@ -505,7 +502,6 @@ public class LightPadWindow : Widgets.CompositedWindow {
 
         if (pos_y + 1 < this.grid_y) {
             this.grid.get_child_at (pos_x, pos_y + 1).grab_focus ();
-            this.queue_draw ();
         }
 
         return true;

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -155,14 +155,16 @@ public class LightPadWindow : Widgets.CompositedWindow {
                     new Gdk.Cursor.for_display (display, Gdk.CursorType.BLANK_CURSOR)
                 );
             }
+            this.children.nth_data (0).grab_focus ();
+        });
 
-            // A short delay before grabbing focus to ensure the window manager has processed the window.
-            // This helps in scenarios where the app starts at boot and might lose focus.
-            GLib.Timeout.add (500, () => {
-                this.present ();
-                this.children.nth_data (0).grab_focus ();
-                return false; // Do not repeat
-            });
+        this.focus_out_event.connect ( () => {
+            var current_item = this.grid.get_children ().index (this.get_focus ());
+            int pos_x = - ((current_item % this.grid_y) - (this.grid_y - 1));
+            int pos_y = - ((current_item / this.grid_y) - (this.grid_x - 1));
+            this.grid.get_child_at (pos_x, pos_y).grab_focus ();
+
+            return true;
         });
 
         // Signals and callbacks

--- a/src/Widgets/AppItem.vala
+++ b/src/Widgets/AppItem.vala
@@ -37,11 +37,7 @@
             // Focused signals
             this.draw.connect (this.draw_background);
             this.focus_in_event.connect ( () => { this.focus_in (); return true; } );
-            this.focus_out_event.connect ( () => { 
-                this.grab_focus ();
-                this.focus_out ();
-                return true; 
-            } );
+            this.focus_out_event.connect ( () => { this.focus_out (); return true; } );
         }
 
         public void change_app (Gdk.Pixbuf? new_icon, string? new_name, string? new_tooltip) {

--- a/src/Widgets/AppItem.vala
+++ b/src/Widgets/AppItem.vala
@@ -37,7 +37,11 @@
             // Focused signals
             this.draw.connect (this.draw_background);
             this.focus_in_event.connect ( () => { this.focus_in (); return true; } );
-            this.focus_out_event.connect ( () => { this.focus_out (); return true; } );
+            this.focus_out_event.connect ( () => { 
+                this.grab_focus ();
+                this.focus_out ();
+                return true; 
+            } );
         }
 
         public void change_app (Gdk.Pixbuf? new_icon, string? new_name, string? new_tooltip) {


### PR DESCRIPTION
Patch to solve a bug that appears when LightPad start on boot with OS (kiosk mode). The dpad direction buttons wont change the focus (was lost)