### PR TITLE
feat: add execution for onload/onexit custom scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,28 @@ If `LIGHTPAD_CATEGORIES` is not set, all available categories will be shown by d
 - Category names must match those defined in your system menu (e.g., "Games", "Internet", "System Tools"). For more information see: [freedesktop.org/menu-spec/categories](https://specifications.freedesktop.org/menu-spec/latest/category-registry.html).
 - Unrecognized category names will be silently ignored.
 
+## Environment Variable: `LIGHTPAD_ONLOAD`
+
+You can execute a script or command when LightPad starts by setting the `LIGHTPAD_ONLOAD` environment variable. The command will be executed before any part of the application is initialized.
+
+LightPad will wait for the command to finish before continuing its own startup process.
+
+**Example:**
+```sh
+export LIGHTPAD_ONLOAD="/path/to/my/setup_script.sh"
+```
+
+## Environment Variable: `LIGHTPAD_ONEXIT`
+
+You can execute a script or command when LightPad exits by setting the `LIGHTPAD_ONEXIT` environment variable. The command is executed after closing internal components (like SDL) and just before the main application window is destroyed.
+
+This script is executed asynchronously, meaning LightPad will not wait for it to complete.
+
+**Example:**
+```sh
+export LIGHTPAD_ONEXIT="/path/to/my/cleanup_script.sh"
+```
+
 ## Icon Cache
 
 To improve startup performance, LightPad now implements a persistent icon cache.

--- a/data/com.github.libredeb.lightpad.1
+++ b/data/com.github.libredeb.lightpad.1
@@ -26,6 +26,17 @@ System Tools, Internet`). The comparison is case-insensitive and ignores extra
 spaces. If unspecified, all available categories are shown. Unrecognized category
 names are silently ignored. Category names must conform to the freedesktop.org
 menu specification.
+.PP
+\-
+\f[B]LIGHTPAD_ONLOAD\f[R]: You can execute a script or command when LightPad starts
+by setting the `LIGHTPAD_ONLOAD` environment variable. The command will be executed
+before any part of the application is initialized.
+.PP
+\-
+\f[B]LIGHTPAD_ONEXIT\f[R]: You can execute a script or command when LightPad exits
+by setting the `LIGHTPAD_ONEXIT` environment variable. The command is executed after
+closing internal components (like SDL) and just before the main application window
+is destroyed.
 .SH FILES
 .TP
 \f[I]\[ti]/.lightpad/blocklist\f[R]

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -628,6 +628,16 @@ public class LightPadWindow : Widgets.CompositedWindow {
             this.monitored_subprocess = null;
         }
 
+        // Run on-exit script if defined
+        string? on_exit_script = GLib.Environment.get_variable ("LIGHTPAD_ONEXIT");
+        if (on_exit_script != null) {
+            try {
+                GLib.Process.spawn_command_line_async (on_exit_script);
+            } catch (GLib.SpawnError e) {
+                warning ("Error executing LIGHTPAD_ONEXIT script: %s", e.message);
+            }
+        }
+
         base.destroy ();
     }
 
@@ -792,6 +802,19 @@ public class LightPadWindow : Widgets.CompositedWindow {
 }
 
 static int main (string[] args) {
+    // Run on-load script if defined
+    string? on_load_script = GLib.Environment.get_variable ("LIGHTPAD_ONLOAD");
+    if (on_load_script != null) {
+        try {
+            string? stdout;
+            string? stderr;
+            int status;
+            GLib.Process.spawn_command_line_sync (on_load_script, out stdout, out stderr, out status);
+        } catch (GLib.SpawnError e) {
+            warning ("Error executing LIGHTPAD_ONLOAD script: %s", e.message);
+        }
+    }
+
     /*
      * This is a workaround for libgnome-menu-3.0, for now doesn't have support to include .desktop entries
      * with the property OnlyShowIn set up. If the value of your XDG_CURRENT_DESKTOP environment variable 


### PR DESCRIPTION
- Add a new feature to execute custom bash scripts both on-load and on-exit LightPad